### PR TITLE
Format code, Thread safety

### DIFF
--- a/src/main/java/com/github/tennaito/rsql/jpa/JpaCriteriaQueryVisitor.java
+++ b/src/main/java/com/github/tennaito/rsql/jpa/JpaCriteriaQueryVisitor.java
@@ -75,8 +75,7 @@ public class JpaCriteriaQueryVisitor<T> extends AbstractJpaVisitor<CriteriaQuery
 	 */
 	public CriteriaQuery<T> visit(AndNode node, EntityManager entityManager) {
 		LOG.log(Level.INFO, "Creating CriteriaQuery for AndNode: {0}", node);
-    	javax.persistence.criteria.CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-    	CriteriaQuery<T> criteria = builder.createQuery(entityClass);
+		CriteriaQuery<T> criteria = entityManager.getCriteriaBuilder().createQuery(entityClass);
     	From root = criteria.from(entityClass);
 		return criteria.where(this.getPredicateVisitor().defineRoot(root).visit(node, entityManager));
 	}
@@ -86,8 +85,7 @@ public class JpaCriteriaQueryVisitor<T> extends AbstractJpaVisitor<CriteriaQuery
 	 */
 	public CriteriaQuery<T> visit(OrNode node, EntityManager entityManager) {
 		LOG.log(Level.INFO, "Creating CriteriaQuery for OrNode: {0}", node);
-    	javax.persistence.criteria.CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-    	CriteriaQuery<T> criteria = builder.createQuery(entityClass);
+		CriteriaQuery<T> criteria = entityManager.getCriteriaBuilder().createQuery(entityClass);
     	From root = criteria.from(entityClass);
 		return criteria.where(this.getPredicateVisitor().defineRoot(root).visit(node, entityManager));
 	}
@@ -97,8 +95,7 @@ public class JpaCriteriaQueryVisitor<T> extends AbstractJpaVisitor<CriteriaQuery
 	 */
 	public CriteriaQuery<T> visit(ComparisonNode node, EntityManager entityManager) {
 		LOG.log(Level.INFO, "Creating CriteriaQuery for ComparisonNode: {0}", node);
-    	javax.persistence.criteria.CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-    	CriteriaQuery<T> criteria = builder.createQuery(entityClass);
+    	CriteriaQuery<T> criteria = entityManager.getCriteriaBuilder().createQuery(entityClass);
     	From root = criteria.from(entityClass);
     	return criteria.where(this.getPredicateVisitor().defineRoot(root).visit(node, entityManager));
 	}

--- a/src/main/java/com/github/tennaito/rsql/jpa/PredicateBuilder.java
+++ b/src/main/java/com/github/tennaito/rsql/jpa/PredicateBuilder.java
@@ -24,15 +24,15 @@
  */
 package com.github.tennaito.rsql.jpa;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.github.tennaito.rsql.builder.BuilderTools;
+import com.github.tennaito.rsql.parser.ast.ComparisonOperatorProxy;
+import cz.jirutka.rsql.parser.ast.ComparisonNode;
+import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+import cz.jirutka.rsql.parser.ast.LogicalNode;
+import cz.jirutka.rsql.parser.ast.Node;
 
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -40,14 +40,11 @@ import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.ManagedType;
 import javax.persistence.metamodel.Metamodel;
 import javax.persistence.metamodel.PluralAttribute;
-
-import com.github.tennaito.rsql.builder.BuilderTools;
-import com.github.tennaito.rsql.parser.ast.ComparisonOperatorProxy;
-
-import cz.jirutka.rsql.parser.ast.ComparisonNode;
-import cz.jirutka.rsql.parser.ast.ComparisonOperator;
-import cz.jirutka.rsql.parser.ast.LogicalNode;
-import cz.jirutka.rsql.parser.ast.Node;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * PredicateBuilder
@@ -103,7 +100,7 @@ public final class PredicateBuilder {
      * @param logical        RSQL AST logical node.
      * @param root           From that predicate expression paths depends on. 
      * @param entity  		 The main entity of the query.
-     * @param manager 		 JPA EntityManager.
+     * @param entityManager  JPA EntityManager.
      * @param misc      	 Facade with all necessary tools for predicate creation.
      * @return 				 Predicate a predicate representation of the Node.
      */
@@ -131,9 +128,9 @@ public final class PredicateBuilder {
      * Create a Predicate from the RSQL AST comparison node.
      *
      * @param comparison	 RSQL AST comparison node.
-     * @param root           From that predicate expression paths depends on. 
+     * @param startRoot      From that predicate expression paths depends on.
      * @param entity  		 The main entity of the query.
-     * @param manager 		 JPA EntityManager.
+     * @param entityManager  JPA EntityManager.
      * @param misc      	 Facade with all necessary tools for predicate creation.
      * @return 				 Predicate a predicate representation of the Node.
      */
@@ -383,7 +380,7 @@ public final class PredicateBuilder {
      * Apply a "in" constraint to the property path.
      *
      * @param propertyPath  Property path that we want to compare.
-     * @param argument      List of arguments.
+     * @param arguments     List of arguments.
      * @param manager       JPA EntityManager.
      * @return              Predicate a predicate representation.
      */
@@ -395,7 +392,7 @@ public final class PredicateBuilder {
      * Apply a "not in" (out) constraint to the property path.
      *
      * @param propertyPath  Property path that we want to compare.
-     * @param argument      List of arguments.
+     * @param arguments     List of arguments.
      * @param manager       JPA EntityManager.
      * @return              Predicate a predicate representation.
      */

--- a/src/main/java/com/github/tennaito/rsql/misc/DefaultArgumentParser.java
+++ b/src/main/java/com/github/tennaito/rsql/misc/DefaultArgumentParser.java
@@ -58,7 +58,7 @@ public class DefaultArgumentParser implements ArgumentParser {
     public <T> T parse(String argument, Class<T> type)
             throws ArgumentFormatException, IllegalArgumentException {
 
-    	LOG.log(Level.INFO, "Parsing argument '{0}' as type {1}", new Object[] {argument, type.getSimpleName()});
+    	LOG.log(Level.INFO, "Parsing argument ''{0}'' as type {1}", new Object[] {argument, type.getSimpleName()});
 
         // Nullable object
         if (argument == null || "null".equals(argument.trim().toLowerCase())) {

--- a/src/main/java/com/github/tennaito/rsql/misc/DefaultArgumentParser.java
+++ b/src/main/java/com/github/tennaito/rsql/misc/DefaultArgumentParser.java
@@ -26,7 +26,6 @@ package com.github.tennaito.rsql.misc;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -48,9 +47,8 @@ public class DefaultArgumentParser implements ArgumentParser {
 
 	private static final Logger LOG = Logger.getLogger(DefaultArgumentParser.class.getName());
 
-    private static final DateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd"); //ISO 8601
-    private static final DateFormat DATE_TIME_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss"); //ISO 8601
-
+    private static final String DATE_PATTERN = "yyyy-MM-dd"; //ISO 8601
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss"; //ISO 8601
 
     /* (non-Javadoc)
      * @see br.tennaito.rsql.misc.ArgumentParser#parse(java.lang.String, java.lang.Class)
@@ -58,7 +56,7 @@ public class DefaultArgumentParser implements ArgumentParser {
     public <T> T parse(String argument, Class<T> type)
             throws ArgumentFormatException, IllegalArgumentException {
 
-    	LOG.log(Level.INFO, "Parsing argument ''{0}'' as type {1}", new Object[] {argument, type.getSimpleName()});
+    	LOG.log(Level.INFO, "Parsing argument ''{0}'' as type {1}, thread {2}", new Object[] {argument, type.getSimpleName(), Thread.currentThread().getName()});
 
         // Nullable object
         if (argument == null || "null".equals(argument.trim().toLowerCase())) {
@@ -80,16 +78,7 @@ public class DefaultArgumentParser implements ArgumentParser {
 
         // date
         if (type.equals(Date.class)) {
-            try {
-                return (T) DATE_TIME_FORMATTER.parse(argument);
-            } catch (ParseException ex) {
-            	LOG.log(Level.INFO, "Not a date time format, lets try with date format.");
-            }
-            try {
-                return (T) DATE_FORMATTER.parse(argument);
-            } catch (ParseException ex1) {
-                throw new ArgumentFormatException(argument, type);
-            }
+            return (T) parseDate(argument, type);
         }
 
         // try to parse via valueOf(String s) method
@@ -105,6 +94,18 @@ public class DefaultArgumentParser implements ArgumentParser {
         }
     }
 
+    private <T> Date parseDate(String argument, Class<T> type) {
+        try {
+            return new SimpleDateFormat(DATE_TIME_PATTERN).parse(argument);
+        } catch (ParseException ex) {
+            LOG.log(Level.INFO, "Not a date time format, lets try with date format.");
+        }
+        try {
+            return new SimpleDateFormat(DATE_PATTERN).parse(argument);
+        } catch (ParseException ex1) {
+            throw new ArgumentFormatException(argument, type);
+        }
+    }
 
 	/* (non-Javadoc)
 	 * @see br.tennaito.rsql.misc.ArgumentParser#parse(java.util.List, java.lang.Class)


### PR DESCRIPTION
SimpleDateFormat is not thread safe - fixed.
Little code format changes (IDE warnings).

Run follow test (DefaultArgumentParserTest) multiple times.
Sometimes you will get different exceptions.

    @Test
    public void testParseArgument_THREAD() {
        for (int i = 0; i < 50; i++) {
            new Thread() {
                @Override
                public void run() {
                    instance.parse("2015-08-20T18:59:59+02:00", Date.class);
                    instance.parse("2015-08-17T05:00:00+02:00", Date.class);
                    instance.parse("2015-08-16T05:00:00+02:00", Date.class);
                    instance.parse("2015-08-15T05:00:00+02:00", Date.class);
                }
            }.start();
        }
    }