### PR TITLE
Changed the join procedure to do a fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.settings
 /.classpath
 /.project
+/.idea/
+*.iml

--- a/src/main/java/com/github/tennaito/rsql/jpa/PredicateBuilder.java
+++ b/src/main/java/com/github/tennaito/rsql/jpa/PredicateBuilder.java
@@ -216,7 +216,9 @@ public final class PredicateBuilder {
                     if (root instanceof Join) {
                         root = root.get(mappedProperty);
                     } else {
-                        root = ((From) root).join(mappedProperty);
+//                        root = ((From) root).join(mappedProperty);
+                        //http://stackoverflow.com/questions/4511368/jpa-2-criteria-fetch-path-navigation
+                        root = (Join)((From) root).fetch(mappedProperty);
                     }
                 } else {
                     LOG.log(Level.INFO, "Create property path for type {0} property {1}.", new Object[]{classMetadata.getJavaType().getName(), mappedProperty});


### PR DESCRIPTION
The current implementation uses a "join" for building the criteria predicate when the RSQL selector is actually a path with dot, e.g. "movie.regisseur". When searching for movies by their regisseurs' firstNames this leads to multiple queries being performed - one for the movies filtered by their regisseurs firstNames and then one for every related regisseur, e.g. 

`Hibernate: select movie0_.id as id1_0_, movie0_.costInMillionDollars as costInMi2_0_, movie0_.isRatedM as isRatedM3_0_, movie0_.regisseur_id as regisseu6_0_, movie0_.title as title4_0_, movie0_.year as year5_0_ from Movie movie0_ inner join Person person1_ on movie0_.regisseur_id=person1_.id where person1_.firstName in (? , ?) order by movie0_.title asc`

`Hibernate: select person0_.id as id1_1_0_, person0_.firstName as firstNam2_1_0_, person0_.lastName as lastName3_1_0_ from Person person0_ where person0_.id=?`

`Hibernate: select person0_.id as id1_1_0_, person0_.firstName as firstNam2_1_0_, person0_.lastName as lastName3_1_0_ from Person person0_ where person0_.id=?`

This can be made more efficient with fetch joins, so that overall only 1 query is executed with the regisseurs being fetched, e.g.

`Hibernate: select movie0_.id as id1_0_0_, person1_.id as id1_1_1_, movie0_.costInMillionDollars as costInMi2_0_0_, movie0_.isRatedM as isRatedM3_0_0_, movie0_.regisseur_id as regisseu6_0_0_, movie0_.title as title4_0_0_, movie0_.year as year5_0_0_, person1_.firstName as firstNam2_1_1_, person1_.lastName as lastName3_1_1_ from Movie movie0_ inner join Person person1_ on movie0_.regisseur_id=person1_.id where person1_.firstName in (? , ?) order by movie0_.title asc`

Please see the link in the code comment, there i found the info about the code-change. 

I am not completely sure, how it will behave on deeper nested paths, e.g. "movie.regisseur.agency.secretary" or so. Also it should be investigated, whether this only works on Hibernate.

Please let me know, what you think, thx!

bye
Simon