### PR TITLE
Avoid ClassCastException when using comparison operators with String types

### DIFF
--- a/src/test/java/com/github/tennaito/rsql/jpa/JpaVisitorTest.java
+++ b/src/test/java/com/github/tennaito/rsql/jpa/JpaVisitorTest.java
@@ -143,6 +143,28 @@ public class JpaVisitorTest extends AbstractVisitorTest<Course> {
 	}
 
 	@Test
+	public void testGreaterThanString() throws Exception {
+		Node rootNode = new RSQLParser().parse("code=gt='ABC'");
+		RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+		CriteriaQuery<Course> query = rootNode.accept(visitor, entityManager);
+
+		List<Course> courses = entityManager.createQuery(query).getResultList();
+		assertEquals(1, courses.size());
+	}
+
+	@Test
+	public void testGreaterThanNotComparable() throws Exception {
+    	try {
+			Node rootNode = new RSQLParser().parse("details.teacher=gt='ABC'");
+			RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+			rootNode.accept(visitor, entityManager);
+			fail("should have failed since type isn't Comparable");
+		} catch (IllegalArgumentException e) {
+    		assertEquals("Invalid type for comparison operator: =gt= type: com.github.tennaito.rsql.jpa.entity.Teacher must implement Comparable<Teacher>", e.getMessage());
+		}
+	}
+
+	@Test
 	public void testGreaterThanEqualSelection() throws Exception {
 		Node rootNode = new RSQLParser().parse("id=ge=1");
 		RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
@@ -160,6 +182,28 @@ public class JpaVisitorTest extends AbstractVisitorTest<Course> {
 
 		List<Course> courses = entityManager.createQuery(query).getResultList();
 		assertEquals("Testing Course", courses.get(0).getName());
+	}
+
+	@Test
+	public void testGreaterThanEqualSelectionForString() throws Exception {
+		Node rootNode = new RSQLParser().parse("code=ge='MI-MDW'");
+		RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+		CriteriaQuery<Course> query = rootNode.accept(visitor, entityManager);
+
+		List<Course> courses = entityManager.createQuery(query).getResultList();
+		assertEquals("Testing Course", courses.get(0).getName());
+	}
+
+	@Test
+	public void testGreaterThanEqualNotComparable() throws Exception {
+		try {
+			Node rootNode = new RSQLParser().parse("details.teacher=ge='ABC'");
+			RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+			rootNode.accept(visitor, entityManager);
+			fail("should have failed since type isn't Comparable");
+		} catch (IllegalArgumentException e) {
+			assertEquals("Invalid type for comparison operator: =ge= type: com.github.tennaito.rsql.jpa.entity.Teacher must implement Comparable<Teacher>", e.getMessage());
+		}
 	}
 
 	@Test
@@ -193,6 +237,28 @@ public class JpaVisitorTest extends AbstractVisitorTest<Course> {
 	}
 
 	@Test
+	public void testLessThanString() throws Exception {
+		Node rootNode = new RSQLParser().parse("code=lt='MI-MDZ'");
+		RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+		CriteriaQuery<Course> query = rootNode.accept(visitor, entityManager);
+
+		List<Course> courses = entityManager.createQuery(query).getResultList();
+		assertEquals(1, courses.size());
+	}
+
+	@Test
+	public void testLessThanNotComparable() throws Exception {
+		try {
+			Node rootNode = new RSQLParser().parse("details.teacher=lt='ABC'");
+			RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+			rootNode.accept(visitor, entityManager);
+			fail("should have failed since type isn't Comparable");
+		} catch (IllegalArgumentException e) {
+			assertEquals("Invalid type for comparison operator: =lt= type: com.github.tennaito.rsql.jpa.entity.Teacher must implement Comparable<Teacher>", e.getMessage());
+		}
+	}
+
+	@Test
 	public void testLessThanEqualSelectionForDate() throws Exception {
 		Node rootNode = new RSQLParser().parse("startDate=le='2100-01-01'");
 		RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
@@ -201,6 +267,29 @@ public class JpaVisitorTest extends AbstractVisitorTest<Course> {
 		List<Course> courses = entityManager.createQuery(query).getResultList();
 		assertEquals("Testing Course", courses.get(0).getName());
 	}
+
+	@Test
+	public void testLessThanEqualSelectionForString() throws Exception {
+		Node rootNode = new RSQLParser().parse("code=le='MI-MDW'");
+		RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+		CriteriaQuery<Course> query = rootNode.accept(visitor, entityManager);
+
+		List<Course> courses = entityManager.createQuery(query).getResultList();
+		assertEquals("Testing Course", courses.get(0).getName());
+	}
+
+	@Test
+	public void testLessThanEqualNotComparable() throws Exception {
+		try {
+			Node rootNode = new RSQLParser().parse("details.teacher=le='ABC'");
+			RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+			rootNode.accept(visitor, entityManager);
+			fail("should have failed since type isn't Comparable");
+		} catch (IllegalArgumentException e) {
+			assertEquals("Invalid type for comparison operator: =le= type: com.github.tennaito.rsql.jpa.entity.Teacher must implement Comparable<Teacher>", e.getMessage());
+		}
+	}
+
 
 	@Test
     public void testInSelection() throws Exception {
@@ -574,12 +663,12 @@ public class JpaVisitorTest extends AbstractVisitorTest<Course> {
 	}
 
 	@Test
-	    public void testSelectionUsingEmbeddedAssociationField() throws Exception {
-			Node rootNode = new RSQLParser().parse("details.teacher.specialtyDescription==Maths");
-			RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
-			CriteriaQuery<Course> query = rootNode.accept(visitor, entityManager);
+	public void testSelectionUsingEmbeddedAssociationField() throws Exception {
+		Node rootNode = new RSQLParser().parse("details.teacher.specialtyDescription==Maths");
+		RSQLVisitor<CriteriaQuery<Course>, EntityManager> visitor = new JpaCriteriaQueryVisitor<Course>();
+		CriteriaQuery<Course> query = rootNode.accept(visitor, entityManager);
 
-			List<Course> courses = entityManager.createQuery(query).getResultList();
-			assertEquals("Testing Course", courses.get(0).getName());
-		}
+		List<Course> courses = entityManager.createQuery(query).getResultList();
+		assertEquals("Testing Course", courses.get(0).getName());
+	}
 }

--- a/src/test/java/com/github/tennaito/rsql/jpa/entity/Teacher.java
+++ b/src/test/java/com/github/tennaito/rsql/jpa/entity/Teacher.java
@@ -17,5 +17,18 @@ public class Teacher extends AbstractTestEntity {
         this.specialtyDescription = specialtyDescription;
     }
 
-
+    /**
+     * Added this method to assist with testing.
+     *
+     * When used with the DefaultArgumentParser, an object requires a valueOf method in order
+     * to be converted from a string.
+     *
+     * @param s name of the teacher
+     * @return Teacher with the name field set but nothing else
+     */
+    public static Teacher valueOf(String s) {
+        Teacher teacher = new Teacher();
+        teacher.setName(s);
+        return teacher;
+    }
 }


### PR DESCRIPTION
The comparison operators >, >=, <, <= in JPQL work with types other than Date and Number. Specifically, Strings should be supported but generically any Comparable type should work.

This PR adds support for any type of Comparable while maintaining the current behavior for Date, Number, and nulls so as to be backwards compatible.

If the argument type is a Date, the current between style logic runs. 
If the argument is a Number or null, then the CriteriaBuilder method that accepts a Number is used. 
If the argument is a Comparable, then the generic Comparable CriteriaBuilder method is used.
If the argument is none of the above, then an IllegalArgumentException is thrown which is preferable to a ClassCastException.