### PR TITLE
Updates and Java 11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    	<maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <!--//////////////////// DEPENDENCIES ////////////////////-->
@@ -49,28 +51,28 @@
         <dependency>
             <groupId>cz.jirutka.rsql</groupId>
             <artifactId>rsql-parser</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
         </dependency>
 
 		<!-- Unfortunately we don´t have a canonical javax.persistence 2.1 yet -->
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>javax.persistence</artifactId>
-			<version>2.1.0</version>
+			<version>2.2.1</version>
 		</dependency>
 
         <!-- Test scope -->
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
-			<version>4.3.10.Final</version>
+			<version>5.4.2.Final</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>eclipselink</artifactId>
-			<version>2.6.0-M3</version>
+			<version>2.7.4</version>
 			<scope>test</scope>
 		</dependency>
         <dependency>
@@ -83,7 +85,7 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>1.8.0.10</version>
+            <version>2.4.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -98,7 +100,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-release-plugin</artifactId>
-						<version>2.5</version>
+						<version>2.5.3</version>
 						<configuration>
 							<autoVersionSubmodules>true</autoVersionSubmodules>
 							<useReleaseProfile>false</useReleaseProfile>
@@ -120,7 +122,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>2.2.1</version>
+						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -133,7 +135,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.9.1</version>
+						<version>3.1.0</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
@@ -146,7 +148,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>1.6</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -188,7 +190,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.7.1.201405082137</version>
+						<version>0.8.3</version>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>
@@ -225,7 +227,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.1.201405082137</version>
+                        <version>0.8.3</version>
                         <executions>
                             <!-- Merge execution data for unit and integration tests. -->
                             <execution>
@@ -263,6 +265,34 @@
             </build>
         </profile>        
     </profiles>
+    <build>
+    <plugins>
+    <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+        <compilerArgs>
+		</compilerArgs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      </plugins>
+    </build>
     
     <!--//////////////////// DISTRIBUTION ////////////////////-->
 	<distributionManagement>


### PR DESCRIPTION
I updated some libraries. Using Java 8 it is ok but on Java 11 the reflection usage in the tests is causing issues.

Signed-off-by: Carsten Hammer <Carsten.Hammer@t-online.de>