### PR TITLE
Set default JoinType to Left Join

### DIFF
--- a/src/main/java/com/github/tennaito/rsql/jpa/PredicateBuilder.java
+++ b/src/main/java/com/github/tennaito/rsql/jpa/PredicateBuilder.java
@@ -32,12 +32,7 @@ import cz.jirutka.rsql.parser.ast.LogicalNode;
 import cz.jirutka.rsql.parser.ast.Node;
 
 import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.Path;
-import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.*;
 import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.Attribute.PersistentAttributeType;
 import javax.persistence.metamodel.ManagedType;
@@ -216,7 +211,7 @@ public final class PredicateBuilder {
                     if (root instanceof Join) {
                         root = root.get(mappedProperty);
                     } else {
-                        root = ((From) root).join(mappedProperty);
+                        root = ((From) root).join(mappedProperty, JointType.LEFT);
                     }
                 } else {
                     LOG.log(Level.INFO, "Create property path for type {0} property {1}.", new Object[]{classMetadata.getJavaType().getName(), mappedProperty});


### PR DESCRIPTION
I found that when I have a query that is as follows the current version doesnt provide the expected result.

Provided you have an Entity Class with a ManyToMany relationship such as User -> Group or User -> Tag then all queries like

(groups.name==group_a or tags.id=1) would not return the expected results (no mathcing results in my case) due to the fact that per default inner Joins are used in JPA.

This change would fix this by utilizing left joins per default.